### PR TITLE
fix: grant lock-threads write permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,6 +5,11 @@ name: 'Lock Threads'
 on:
   schedule:
     - cron: '43 20 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   lock:


### PR DESCRIPTION
## Summary
- Scheduled Lock Threads failed: `Resource not accessible by integration` (or v5 token length error on scaffolding)
- Add `permissions: issues/pull-requests: write`, pin `dessant/lock-threads@v6.0.2`, add `workflow_dispatch`

Closes #16

## Test plan
- [ ] CI green on the PR
- [ ] After merge, run Lock Threads via workflow_dispatch and confirm success